### PR TITLE
add postgres/login/default.sql with a test user

### DIFF
--- a/postgres/login/README.md
+++ b/postgres/login/README.md
@@ -1,0 +1,9 @@
+# Login database configurations
+
+## default.sql
+
+Contains the following user
+
+| id                          | name   | email              | password |
+|-----------------------------|--------|--------------------|----------|
+| `cl6lxrq2g000460o0zs9dmy6v` | `test` | `test@example.com` | `test`   |

--- a/postgres/login/default.sql
+++ b/postgres/login/default.sql
@@ -1,1 +1,101 @@
-SELECT CURRENT_TIME;
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 14.4
+-- Dumped by pg_dump version 14.4
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: User; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public."User" (
+    id text NOT NULL,
+    "createdAt" timestamp(3) without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    name text NOT NULL,
+    email text NOT NULL,
+    "passwordHash" text NOT NULL
+);
+
+
+ALTER TABLE public."User" OWNER TO postgres;
+
+--
+-- Name: _prisma_migrations; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public._prisma_migrations (
+    id character varying(36) NOT NULL,
+    checksum character varying(64) NOT NULL,
+    finished_at timestamp with time zone,
+    migration_name character varying(255) NOT NULL,
+    logs text,
+    rolled_back_at timestamp with time zone,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    applied_steps_count integer DEFAULT 0 NOT NULL
+);
+
+
+ALTER TABLE public._prisma_migrations OWNER TO postgres;
+
+--
+-- Data for Name: User; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public."User" (id, "createdAt", name, email, "passwordHash") FROM stdin;
+cl6lxrq2g000460o0zs9dmy6v	2022-08-09 08:44:10.552	test	test@example.com	$2a$10$Z9vuRs7Aw4QhdOx02rPleupU24Jb9iUYo1whCq/J2cPFYLtG2giky
+\.
+
+
+--
+-- Data for Name: _prisma_migrations; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+COPY public._prisma_migrations (id, checksum, finished_at, migration_name, logs, rolled_back_at, started_at, applied_steps_count) FROM stdin;
+a7dc0700-2f38-4571-946e-6f2dd37ed993	ebc568765c5be16d0ec9449e06d4878573f67da0e917afcf703c057ec60f8b48	2022-08-09 08:41:34.043724+00	20220502145902_initial_user_model	\N	\N	2022-08-09 08:41:34.033906+00	1
+ed8c463a-00de-46b0-b729-07ff63efadc1	95c962c9c5d06171551475a650e1fcf2bc62251fa8b74eea43abd59f8500c034	2022-08-09 08:41:34.050126+00	20220502170119_make_username_unique	\N	\N	2022-08-09 08:41:34.04485+00	1
+\.
+
+
+--
+-- Name: User User_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public."User"
+    ADD CONSTRAINT "User_pkey" PRIMARY KEY (id);
+
+
+--
+-- Name: _prisma_migrations _prisma_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public._prisma_migrations
+    ADD CONSTRAINT _prisma_migrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: User_name_key; Type: INDEX; Schema: public; Owner: postgres
+--
+
+CREATE UNIQUE INDEX "User_name_key" ON public."User" USING btree (name);
+
+
+--
+-- PostgreSQL database dump complete
+--
+


### PR DESCRIPTION
Part of Gamify-IT/issues#200

# How to test this

- clone the overworld-backend repository
- checkout the branch `feature/dummy-data`
- go into the `docker-compose.yaml` file
- Replace
  ```
  setup:
    container_name: setup
    image: ghcr.io/gamify-it/test-data:latest
    pull_policy: always
    restart: on-failure
    environment:
      POSTGRES_SETUP: >
        login/default.sql
        overworld/default.sql
  ```
  with
  ```
  setup:
    container_name: setup
    image: ghcr.io/gamify-it/test-data:feature-login-dataset
    pull_policy: always
    restart: on-failure
    environment:
      POSTGRES_SETUP: >
        login/default.sql
        overworld/default.sql
  ```
  to use the data container from this branch
- run `docker-compose up`
- go to http://localhost
- try to log in with user `test` password `test`